### PR TITLE
Fix typo

### DIFF
--- a/f-re.html
+++ b/f-re.html
@@ -480,7 +480,7 @@ but don't control the flags passed to the <a href="https://docs.python.org/3/lib
 <h3 id="bonus-i-don-t-use-python">Bonus: I don't use Python<span class="headerlink"> <a href="#bonus-i-don-t-use-python" title="permalink">#</a></span></h3>
 <p>Lots of other languages support the inline verbose flag, too!
 You can build a pattern in whichever language is more convenient,
-and use it in any other one.<sup class="footnote-ref" id="fnref-3"><a href="#fn-3">3</a></sup> Languges like...</p>
+and use it in any other one.<sup class="footnote-ref" id="fnref-3"><a href="#fn-3">3</a></sup> Languages like...</p>
 <p>C (with <a href="https://en.wikipedia.org/wiki/Perl_Compatible_Regular_Expressions">PCRE</a> – and by extension, C++, PHP, and many others):</p>
 <div class="highlight code-container"><pre class="code" data-lang="Bash"><span></span><code><span class="nb">echo</span> <span class="s1">&#39;0123&#39;</span> <span class="p">|</span> pcregrep -o <span class="s1">&#39;(?x)</span>
 <span class="s1">1 2  # such inline</span>


### PR DESCRIPTION
`Languges` -> `Languages`
(I should probably be editing the markdown file instead of the html file, but I couldn't locate the markdown file.)